### PR TITLE
Fix qtwebengine build with python 3.12

### DIFF
--- a/x11/qt5/qtwebengine/Makefile
+++ b/x11/qt5/qtwebengine/Makefile
@@ -135,6 +135,7 @@ pre-build:
 	${SUBST_CMD} ${CHROMESRC}/build/gn_run_binary.py \
 		${CHROMESRC}/v8/tools/run.py \
 		${CHROMESRC}/tools/protoc_wrapper/protoc_wrapper.py
+	rm -r ${CHROMESRC}/tools/grit/third_party/six
 
 pre-fake:
 # Fix version mismatches for CMake

--- a/x11/qt5/qtwebengine/patches/patch-src_3rdparty_chromium_components_resources_protobufs_binary_proto_generator_py
+++ b/x11/qt5/qtwebengine/patches/patch-src_3rdparty_chromium_components_resources_protobufs_binary_proto_generator_py
@@ -1,0 +1,27 @@
+Fix build with Python 3.12
+https://www.linuxfromscratch.org/~ken/fontconfig-systemd/x/qtwebengine.html
+
+Index: src/3rdparty/chromium/components/resources/protobufs/binary_proto_generator.py
+--- src/3rdparty/chromium/components/resources/protobufs/binary_proto_generator.py.orig
++++ src/3rdparty/chromium/components/resources/protobufs/binary_proto_generator.py
+@@ -21,7 +21,7 @@ PY34 = sys.version_info[0:2] >= (3, 4)
+ if PY34:
+   from importlib import util as imp_util
+ else:
+-  import imp
++  import importlib.util
+ 
+ class GoogleProtobufModuleImporter:
+   """A custom module importer for importing google.protobuf.
+@@ -79,7 +79,10 @@ class GoogleProtobufModuleImporter:
+       spec.loader.exec_module(loaded)
+ 
+     else:
+-      return imp.load_source(fullname, filepath)
++      spec = importlib.util.spec_from_file_location(fullname, filepath)
++      mod = importlib.util.module_from_spec(spec)
++      spec.loader.exec_module(mod)
++      return mod
+ 
+     return loaded
+ 

--- a/x11/qt5/qtwebengine/patches/patch-src_3rdparty_chromium_mojo_public_tools_mojom_mojom_fileutil_py
+++ b/x11/qt5/qtwebengine/patches/patch-src_3rdparty_chromium_mojo_public_tools_mojom_mojom_fileutil_py
@@ -1,0 +1,14 @@
+Fix build with Python 3.12
+https://www.linuxfromscratch.org/~ken/fontconfig-systemd/x/qtwebengine.html
+
+Index: src/3rdparty/chromium/mojo/public/tools/mojom/mojom/fileutil.py
+--- src/3rdparty/chromium/mojo/public/tools/mojom/mojom/fileutil.py.orig
++++ src/3rdparty/chromium/mojo/public/tools/mojom/mojom/fileutil.py
+@@ -3,7 +3,6 @@
+ # found in the LICENSE file.
+ 
+ import errno
+-import imp
+ import os.path
+ import sys
+ 

--- a/x11/qt5/qtwebengine/patches/patch-src_3rdparty_chromium_mojo_public_tools_mojom_mojom_parse_lexer_py
+++ b/x11/qt5/qtwebengine/patches/patch-src_3rdparty_chromium_mojo_public_tools_mojom_mojom_parse_lexer_py
@@ -1,0 +1,14 @@
+Fix build with Python 3.12
+https://www.linuxfromscratch.org/~ken/fontconfig-systemd/x/qtwebengine.html
+
+Index: src/3rdparty/chromium/mojo/public/tools/mojom/mojom/parse/lexer.py
+--- src/3rdparty/chromium/mojo/public/tools/mojom/mojom/parse/lexer.py.orig
++++ src/3rdparty/chromium/mojo/public/tools/mojom/mojom/parse/lexer.py
+@@ -2,7 +2,6 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-import imp
+ import os.path
+ import sys
+ 


### PR DESCRIPTION
Tested on amd64. The rm -r bit of the Makefile should probably be moved from pre-build to post-extract. Based on
https://www.linuxfromscratch.org/~ken/fontconfig-systemd/x/qtwebengine.html